### PR TITLE
Add streetwear branding with text logo and npm setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/cart.html
+++ b/cart.html
@@ -3,13 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Your Cart - Withdrawls Store</title>
+  <title>Your Cart - Withdrawls Streetwear</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
   <header class="container">
     <nav class="nav">
-      <a href="/" class="logo">Withdrawls</a>
+      <a href="/" class="logo">Withdrawls Streetwear</a>
       <button id="menuBtn" aria-expanded="false" aria-controls="menu">☰</button>
       <ul id="menu" class="menu">
         <li><a href="index.html">Shop</a></li>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,15 +1,17 @@
 /* Basic reset & colors */
 :root {
-  --bg: #0d1117;
-  --fg: #e6edf3;
-  --muted: #9ca3af;
-  --accent: #3b82f6;
-  --card: #161b22;
-  --border: #30363d;
+  --bg: #000;
+  --fg: #f5f5f5;
+  --muted: #a0a0a0;
+  --accent: #ff0055;
+  --card: #111;
+  --border: #333;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
 body {
-  font: 16px/1.6 system-ui, sans-serif;
+  font-family: 'Roboto', sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
   background: var(--bg);
   color: var(--fg);
 }
@@ -21,19 +23,35 @@ body {
 
 /* NAVIGATION */
 .nav { display: flex; align-items: center; gap: 1rem; }
-.logo { font-weight: bold; color: var(--fg); text-decoration: none; font-size: 1.2rem; }
+.logo {
+  text-decoration: none;
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 1.5rem;
+  color: var(--fg);
+  text-transform: uppercase;
+}
 .menu { list-style: none; display: flex; gap: 1rem; margin-left: auto; }
 .menu li a { color: var(--fg); text-decoration: none; }
 #menuBtn { display: none; background: none; border: none; font-size: 1.5rem; color: var(--fg); cursor: pointer; }
 
 /* HERO */
 .hero { text-align: center; padding: 6rem 0; }
-.hero h1 { font-size: clamp(2rem, 5vw, 3rem); }
+.hero h1 {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
 .hero span { color: var(--accent); }
 .hero p { margin: 1rem 0; color: var(--muted); }
 
 /* SECTIONS */
-h2 { margin-bottom: 1rem; }
+h2 {
+  margin-bottom: 1rem;
+  font-family: 'Bebas Neue', sans-serif;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
 p { margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(3, 1fr); }
 article {

--- a/index.html
+++ b/index.html
@@ -3,14 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Withdrawls Store</title>
-  <meta name="description" content="Withdrawls - Demo online store" />
+  <title>Withdrawls Streetwear</title>
+  <meta name="description" content="Withdrawls Streetwear - Demo online store" />
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
   <header class="container">
     <nav class="nav">
-      <a href="/" class="logo">Withdrawls</a>
+      <a href="/" class="logo">Withdrawls Streetwear</a>
       <button id="menuBtn" aria-expanded="false" aria-controls="menu">☰</button>
       <ul id="menu" class="menu">
         <li><a href="#products">Shop</a></li>
@@ -20,8 +21,8 @@
   </header>
 
   <section class="hero container">
-    <h1>Welcome to <span>Withdrawls Store</span></h1>
-    <p>Select from our range of awesome widgets.</p>
+    <h1>Welcome to <span>Withdrawls Streetwear</span></h1>
+    <p>Discover our latest urban apparel drops.</p>
   </section>
 
   <section id="products" class="container">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "withdrawls",
+  "version": "1.0.0",
+  "description": "Streetwear store demo",
+  "scripts": {
+    "start": "lite-server",
+    "test": "echo \"No tests\""
+  },
+  "devDependencies": {
+    "lite-server": "^2.6.1"
+  },
+  "private": true
+}


### PR DESCRIPTION
## Summary
- Replace image logo with text-based branding to remove unsupported binary assets
- Refresh theme with streetwear color palette and fonts
- Apply branding across cart page and set up npm tooling

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lite-server)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b21613a31c832d8a0f71a5ed655a8e