### PR TITLE
Style hero heading with orange Old English text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -42,7 +42,12 @@ body {
   letter-spacing: 1px;
   text-transform: uppercase;
 }
-.hero span { color: var(--accent); }
+.hero-top { display: block; }
+.hero-highlight {
+  display: block;
+  color: orange;
+  font-family: 'UnifrakturCook', 'Old English Text MT', serif;
+}
 .hero p { margin: 1rem 0; color: var(--muted); }
 
 /* SECTIONS */

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Withdrawls Streetwear</title>
   <meta name="description" content="Withdrawls Streetwear - Demo online store" />
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&family=UnifrakturCook:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
@@ -21,7 +21,10 @@
   </header>
 
   <section class="hero container">
-    <h1>Welcome to <span>Withdrawls Streetwear</span></h1>
+    <h1>
+      <span class="hero-top">Welcome to</span>
+      <span class="hero-highlight">Withdrawls Streetwear</span>
+    </h1>
     <p>Discover our latest urban apparel drops.</p>
   </section>
 


### PR DESCRIPTION
## Summary
- Set hero heading on two lines
- Change accent text to orange and use an Old English font

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2efc6d0c4832daf5df27ed2d192c5