### PR TITLE
Improve orange accent readability and button styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3,7 +3,7 @@
   --bg: #000;
   --fg: #f5f5f5;
   --muted: #a0a0a0;
-  --accent: #ff0055;
+  --accent: #ffa500;
   --card: #111;
   --border: #333;
 }
@@ -77,7 +77,7 @@ button.btn, a.btn {
   padding: 0.6rem 1rem;
   border-radius: 8px;
   background: var(--accent);
-  color: #fff;
+  color: #000;
   text-decoration: none;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- brighten orange accent color for improved readability across text elements
- style Add to Cart buttons with orange background and black text for better contrast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f23e3d74832dae4159605746951c