### PR TITLE
Replace nav text with Withdrawls.Shop logo

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -10,7 +10,7 @@
 <body>
   <header class="container">
     <nav class="nav">
-      <a href="/" class="logo">Withdrawls Streetwear</a>
+      <a href="/" class="logo"><img src="img/logo.svg" alt="Withdrawls.Shop logo"></a>
       <button id="menuBtn" aria-expanded="false" aria-controls="menu">☰</button>
       <ul id="menu" class="menu">
         <li><a href="index.html">Shop</a></li>

--- a/css/styles.css
+++ b/css/styles.css
@@ -24,11 +24,13 @@ body {
 /* NAVIGATION */
 .nav { display: flex; align-items: center; gap: 1rem; }
 .logo {
-  text-decoration: none;
-  font-family: 'Bebas Neue', sans-serif;
-  font-size: 1.5rem;
-  color: var(--fg);
-  text-transform: uppercase;
+  display: inline-block;
+  height: 40px;
+}
+
+.logo img {
+  height: 100%;
+  display: block;
 }
 .menu { list-style: none; display: flex; gap: 1rem; margin-left: auto; }
 .menu li a { color: var(--fg); text-decoration: none; }

--- a/img/logo.svg
+++ b/img/logo.svg
@@ -1,0 +1,15 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'>
+  <rect width='200' height='200' fill='none'/>
+  <rect x='40' y='20' width='120' height='40' rx='5' ry='5' fill='#35823c'/>
+  <rect x='60' y='60' width='80' height='60' fill='#f4f2d2' stroke='#35823c' stroke-width='4'/>
+  <circle cx='100' cy='90' r='20' fill='#35823c'/>
+  <text x='100' y='96' text-anchor='middle' font-family="Bebas Neue, sans-serif" font-size='24' fill='#f4f2d2'>$</text>
+  <path d='M100 120 L120 140 H110 V160 H90 V140 H80 Z' fill='#d07c15'/>
+  <text x='100' y='185' text-anchor='middle'
+        font-family="Bebas Neue, sans-serif"
+        font-size='24' fill='#f5f5f5'>WITHDRAWLS</text>
+  <text x='100' y='200' text-anchor='middle'
+        font-family="Bebas Neue, sans-serif"
+        font-size='24' fill='#d07c15'>.SHOP</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <header class="container">
     <nav class="nav">
-      <a href="/" class="logo">Withdrawls Streetwear</a>
+      <a href="/" class="logo"><img src="img/logo.svg" alt="Withdrawls.Shop logo"></a>
       <button id="menuBtn" aria-expanded="false" aria-controls="menu">☰</button>
       <ul id="menu" class="menu">
         <li><a href="#products">Shop</a></li>


### PR DESCRIPTION
## Summary
- replace text-based site name in header with `img/logo.svg`
- adjust nav styles to size and display the logo
- add vector logo asset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f9a5a140832da10185194c67bd3a