### PR TITLE
Add Stripe checkout for payments

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Withdrawls Streetwear - Demo online store" />
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
+  <meta name="stripe-pk" content="pk_test_placeholder" />
 </head>
 <body>
   <header class="container">

--- a/js/script.js
+++ b/js/script.js
@@ -114,6 +114,20 @@ if (cartItems) {
     saveCart([]);
     location.reload();
   });
+
+  document.getElementById('checkout')?.addEventListener('click', async () => {
+    const cart = getCart();
+    if (cart.length === 0) return;
+    const res = await fetch('/create-checkout-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items: cart })
+    });
+    const data = await res.json();
+    const pk = document.querySelector('meta[name="stripe-pk"]')?.content || 'pk_test_placeholder';
+    const stripe = Stripe(pk);
+    await stripe.redirectToCheckout({ sessionId: data.id });
+  });
 }
 
 updateCartCount();

--- a/package.json
+++ b/package.json
@@ -3,8 +3,13 @@
   "version": "1.0.0",
   "description": "Streetwear store demo",
   "scripts": {
-    "start": "lite-server",
+    "start": "node server.js",
+    "dev": "lite-server",
     "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "stripe": "^12.5.0"
   },
   "devDependencies": {
     "lite-server": "^2.6.1"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY || 'sk_test_placeholder');
+const app = express();
+
+app.use(express.static('.'));
+app.use(express.json());
+
+const products = [
+  { id: 1, name: 'Widget', price: 1999 },
+  { id: 2, name: 'Gadget', price: 2999 },
+  { id: 3, name: 'Doohickey', price: 999 }
+];
+
+app.post('/create-checkout-session', async (req, res) => {
+  try {
+    const lineItems = req.body.items.map((item) => {
+      const product = products.find((p) => p.id === item.id);
+      return {
+        price_data: {
+          currency: 'usd',
+          product_data: { name: product.name },
+          unit_amount: product.price,
+        },
+        quantity: item.qty,
+      };
+    });
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: lineItems,
+      success_url: `${req.headers.origin}/success.html`,
+      cancel_url: `${req.headers.origin}/cart.html`,
+    });
+    res.json({ id: session.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server running on port ${port}`));

--- a/success.html
+++ b/success.html
@@ -3,36 +3,28 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Your Cart - Withdrawls Streetwear</title>
+  <title>Payment Success</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
-  <meta name="stripe-pk" content="pk_test_placeholder" />
 </head>
 <body>
   <header class="container">
     <nav class="nav">
       <a href="/" class="logo"><img src="img/logo.svg" alt="Withdrawls.Shop logo"></a>
-      <button id="menuBtn" aria-expanded="false" aria-controls="menu">☰</button>
-      <ul id="menu" class="menu">
+      <ul class="menu">
         <li><a href="index.html">Shop</a></li>
-        <li><a href="cart.html">Cart (<span id="cartCount">0</span>)</a></li>
+        <li><a href="cart.html">Cart</a></li>
       </ul>
     </nav>
   </header>
-
   <main class="container">
-    <h1>Your Cart</h1>
-    <div id="cartItems"></div>
-    <p id="cartTotal"></p>
-    <button id="clearCart" class="btn">Clear Cart</button>
-    <button id="checkout" class="btn">Checkout</button>
+    <h1>Thank you for your purchase!</h1>
+    <p>Your payment was successful.</p>
+    <a href="index.html" class="btn">Continue Shopping</a>
   </main>
-
   <footer class="container">
     <small>© <span id="year"></span> Withdrawls. All rights reserved.</small>
   </footer>
-
-  <script src="https://js.stripe.com/v3/"></script>
   <script src="js/script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Stripe Checkout using a small Express server
- add checkout button on cart page and redirect to Stripe
- include a success page after payment

## Testing
- `npm install express stripe` (fails: 403 Forbidden)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bffa967168832d9ce76a5682a1ec24